### PR TITLE
Catch argument exceptions to stop a hard crash from occurring 

### DIFF
--- a/WindowsPathEditor/PathEntry.cs
+++ b/WindowsPathEditor/PathEntry.cs
@@ -53,7 +53,12 @@ namespace WindowsPathEditor
             {
                 return Directory.EnumerateFiles(ActualPath, prefix + "*")
                     .Select(file => new PathMatch(ActualPath, Path.GetFileName(file)));
-            } catch (IOException)
+            } 
+            catch (IOException)
+            {
+                return Enumerable.Empty<PathMatch>();
+            } 
+            catch(ArgumentException)
             {
                 return Enumerable.Empty<PathMatch>();
             }


### PR DESCRIPTION
(cont) when entering a malformed string into the search textbox.

Happened when I didn't understand what the "Search" box was for and entered in a windows path which caused a hard crash.

Repro:
1.) Open application
2.) Copy a windows path (C:\Windows\system32\drivers)
3.) Paste into "Type to search" textbox 
4.) Observe hard crash.

Proposed solution:
Catch ArgumentExceptions caused by entering a malformed input by displaying no matches found.