### PR TITLE
Fixing issue #18: Drag n'drop not working anymore after reordering items

### DIFF
--- a/WindowsPathEditor/DragDropListBox/DraggedAdorner.cs
+++ b/WindowsPathEditor/DragDropListBox/DraggedAdorner.cs
@@ -35,7 +35,7 @@ namespace DragDropListBox
 			// near the mouse cursor when dragging.
 			this.left = left - 1;
 			this.top = top + 13;
-			if (this.adornerLayer != null)
+            if (this.adornerLayer != null && this.contentPresenter.Content != null)
 			{
 				this.adornerLayer.Update(this.AdornedElement);
 			}


### PR DESCRIPTION
Fixed applying http://stackoverflow.com/questions/8655814/cannot-access-adorners-on-element-that-has-no-adorners 
PS: I didn't dig enough to understand why the content presenter's content would be null after reordering. But this seems to fix the error. Goof enough for me.